### PR TITLE
CSR lesson

### DIFF
--- a/components/docs/docs.mdx
+++ b/components/docs/docs.mdx
@@ -429,6 +429,8 @@ export default Home
 
 ```jsx
 // pages/about.js
+import Link from 'next/link'
+
 function About() {
   return (
     <>
@@ -468,7 +470,7 @@ const MyButton = React.forwardRef(({ onClick, href }, ref) => (
 
 export default () => (
   <>
-    <Link href='/another'>
+    <Link href="/another">
       <MyButton />
     </Link>
   </>
@@ -829,7 +831,7 @@ componentDidUpdate(prevProps) {
   </ul>
 </details>
 
-If you want to access the `router` object inside any component in your app, you can use the `useRouter` hook, here's how to use it:
+If you want to access the `router` object inside any functional component in your app, you can use the `useRouter` hook, here's how to use it:
 
 ```jsx
 import { useRouter } from 'next/router'
@@ -853,6 +855,9 @@ export default function ActiveLink({ children, href }) {
   )
 }
 ```
+
+> **Note**: `useRouter` is a React hook, meaning it cannot be used with classes.
+> You can either use [`withRouter`](#using-a-higher-order-component) (a higher order component) or wrap your class in a functional component.
 
 The above `router` object comes with an API similar to [`next/router`](#imperatively).
 
@@ -893,6 +898,8 @@ Next.js has an API which allows you to prefetch pages.
 Since Next.js server-renders your pages, this allows all the future interaction paths of your app to be instant. Effectively Next.js gives you the great initial download performance of a _website_, with the ahead-of-time download capabilities of an _app_. [Read more](https://zeit.co/blog/next#anticipation-is-the-key-to-performance).
 
 > With prefetching Next.js only downloads JS code. When the page is getting rendered, you may need to wait for the data.
+
+> Automatic prefetching is disabled if your device is connected with 2G network or [Save-Data](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Save-Data) header is `on`.
 
 > `<link rel="preload">` is used for prefetching. Sometimes browsers will show a warning if the resource is not used within 3 seconds, these warnings can be ignored as per https://github.com/zeit/next.js/issues/6517#issuecomment-469063892.
 
@@ -1007,7 +1014,7 @@ export default (req, res) => {
 
 - `res` refers to [NextApiResponse](https://github.com/zeit/next.js/blob/v9.0.0/packages/next-server/lib/utils.ts#L168-L178) which extends [http.ServerResponse](https://nodejs.org/api/http.html#http_class_http_serverresponse)
 
-For [API routes](#api-routes) there are build in types `NextApiRequest` and `NextApiResponse`, which extend the `Node.js` request and response objects.
+For [API routes](#api-routes) there are built-in types `NextApiRequest` and `NextApiResponse`, which extend the `Node.js` request and response objects.
 
 ```ts
 import { NextApiRequest, NextApiResponse } from 'next'
@@ -1541,21 +1548,19 @@ export default MyDocument
 ```jsx
 import React from 'react'
 
-class Error extends React.Component {
-  static getInitialProps({ res, err }) {
-    const statusCode = res ? res.statusCode : err ? err.statusCode : null
-    return { statusCode }
-  }
+function Error({ statusCode }) {
+  return (
+    <p>
+      {statusCode
+        ? `An error ${statusCode} occurred on server`
+        : 'An error occurred on client'}
+    </p>
+  )
+}
 
-  render() {
-    return (
-      <p>
-        {this.props.statusCode
-          ? `An error ${this.props.statusCode} occurred on server`
-          : 'An error occurred on client'}
-      </p>
-    )
-  }
+Error.getInitialProps = ({ res, err }) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : null
+  return { statusCode }
 }
 
 export default Error
@@ -1570,22 +1575,20 @@ import React from 'react'
 import Error from 'next/error'
 import fetch from 'isomorphic-unfetch'
 
-class Page extends React.Component {
-  static async getInitialProps() {
-    const res = await fetch('https://api.github.com/repos/zeit/next.js')
-    const errorCode = res.statusCode > 200 ? res.statusCode : false
-    const json = await res.json()
-
-    return { errorCode, stars: json.stargazers_count }
+const Page = ({ errorCode, stars }) => {
+  if (errorCode) {
+    return <Error statusCode={errorCode} />
   }
 
-  render() {
-    if (this.props.errorCode) {
-      return <Error statusCode={this.props.errorCode} />
-    }
+  return <div>Next stars: {stars}</div>
+}
 
-    return <div>Next stars: {this.props.stars}</div>
-  }
+Page.getInitialProps = async () => {
+  const res = await fetch('https://api.github.com/repos/zeit/next.js')
+  const errorCode = res.statusCode > 200 ? res.statusCode : false
+  const json = await res.json()
+
+  return { errorCode, stars: json.stargazers_count }
 }
 
 export default Page
@@ -1618,7 +1621,7 @@ module.exports = (phase, { defaultConfig }) => {
 }
 ```
 
-`phase` is the current context in which the configuration is loaded. You can see all phases here: [constants](https://github.com/zeit/next.js/tree/canary/packages/next-server/lib/constants.ts)
+`phase` is the current context in which the configuration is loaded. You can see all phases here: [constants](https://github.com/zeit/next.js/tree/canary/packages/next/next-server/lib/constants.ts)
 Phases can be imported from `next/constants`:
 
 ```js
@@ -2026,6 +2029,20 @@ There is no configuration or special handling required.
 > **Note**: If you have a [custom `<Document>`](#custom-document) with `getInitialProps` be sure you check if `ctx.req` is defined before assuming the page is server-side rendered.
 > `ctx.req` will be `undefined` for pages that are prerendered.
 
+## Automatic Prerender Indicator
+
+When a page qualifies for automatic prerendering we show an indicator to let you know. This is helpful since the automatic prerendering optimization can be very beneficial and knowing immediately in development if it qualifies can be useful. See above for information on the benefits of this optimization.
+
+In some cases this indicator might not be as useful like when working on electron applications. For these cases you can disable the indicator in your `next.config.js` by setting
+
+```js
+module.exports = {
+  devIndicators: {
+    autoPrerender: false,
+  },
+}
+```
+
 ## Production deployment
 
 To deploy, instead of running `next`, you want to build for production usage ahead of time. Therefore, building and starting are separate commands:
@@ -2044,6 +2061,7 @@ Note: `NODE_ENV` is properly configured by the `next` subcommands, if absent, to
 Note: we recommend putting `.next`, or your [custom dist folder](https://github.com/zeit/next.js#custom-configuration), in `.gitignore` or `.npmignore`. Otherwise, use `files` or `now.files` to opt-into a whitelist of files you want to deploy, excluding `.next` or your custom dist folder.
 
 ### Compression
+
 Next.js provides [gzip](https://tools.ietf.org/html/rfc6713#section-3) compression to compress rendered content and static files. Compression only works with the `server` target. In general you will want to enable compression on a HTTP proxy like [nginx](https://www.nginx.com/), to offload load from the `Node.js` process.
 
 To disable **compression** in Next.js, set `compress` to `false` in `next.config.js`:
@@ -2581,7 +2599,7 @@ Next.js bundles [styled-jsx](https://github.com/zeit/styled-jsx) supporting scop
 
 We track V8. Since V8 has wide support for ES6 and `async` and `await`, we transpile those. Since V8 doesn’t support class decorators, we don’t transpile those.
 
-See the documentation about [customizing the babel config](#customizing-babel-config) and [next/preset](https://github.com/zeit/next.js/tree/canary/packages/next/build/babel/preset.js) for more information.
+See the documentation about [customizing the babel config](#customizing-babel-config) and [next/preset](https://github.com/zeit/next.js/tree/canary/packages/next/build/babel/preset.ts) for more information.
 
 </details>
 

--- a/components/learn/Markdown.js
+++ b/components/learn/Markdown.js
@@ -97,7 +97,7 @@ const InlineCode = ({ children }) => (
     {children}
     <style jsx>{`
       code {
-        color: #313131;
+        color: rgb(212, 0, 255);
         font-size: 14px;
         white-space: pre-wrap;
       }

--- a/lib/learn/courses.js
+++ b/lib/learn/courses.js
@@ -447,7 +447,7 @@ const courses = [
           },
           {
             id: 'common-hooks',
-            points: 25
+            points: 15
           }
         ]
       }

--- a/lib/learn/courses.js
+++ b/lib/learn/courses.js
@@ -424,6 +424,32 @@ const courses = [
             points: 5
           }
         ]
+      },
+      {
+        id: 'csr',
+        name: 'CSR',
+        steps: [
+          {
+            id: 'setup',
+            points: 5
+          },
+          {
+            id: 'ssr-app',
+            points: 20
+          },
+          {
+            id: 'slow-navigation',
+            points: 5
+          },
+          {
+            id: 'hooks',
+            points: 10
+          },
+          {
+            id: 'common-hooks',
+            points: 25
+          }
+        ]
       }
     ]
   }

--- a/lib/learn/courses.js
+++ b/lib/learn/courses.js
@@ -448,6 +448,26 @@ const courses = [
           {
             id: 'common-hooks',
             points: 15
+          },
+          {
+            id: 'client-side-fetching',
+            points: 25
+          },
+          {
+            id: 'automatic-prerendering',
+            points: 5
+          },
+          {
+            id: 'browser-apis',
+            points: 20
+          },
+          {
+            id: 'browser-apis-2',
+            points: 10
+          },
+          {
+            id: 'finally',
+            points: 5
           }
         ]
       }

--- a/next.config.js
+++ b/next.config.js
@@ -42,7 +42,8 @@ const nextConfig = {
   target: 'serverless',
   pageExtensions: ['jsx', 'js', 'ts', 'tsx', 'mdx'],
   experimental: {
-    publicDirectory: true
+    publicDirectory: true,
+    granularChunks: true
   },
   env: {
     BACKEND_URL,

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,6 @@
 import '../lib/polyfill';
 import React from 'react';
-import App, { Container } from 'next/app';
+import App from 'next/app';
 import url from 'url';
 
 import { setToken, removeToken, getToken, getTokenPayload } from '../lib/learn/authenticate';
@@ -63,12 +63,12 @@ export default class MyApp extends App {
     const { Component, pageProps, user } = this.props;
 
     return (
-      <Container>
+      <>
         <UserProvider user={user}>
           <Component {...pageProps} />
         </UserProvider>
         <NProgress />
-      </Container>
+      </>
     );
   }
 }

--- a/pages/learn/excel/csr/automatic-prerendering.mdx
+++ b/pages/learn/excel/csr/automatic-prerendering.mdx
@@ -21,7 +21,7 @@ id: '975';
 
 the id is `undefined` in the first render but then it changes to `975`, which is the id for http://localhost:3000/p/975.
 
-This happens because of [Automatic Prerendering](https://nextjs.org/docs#automatic-prerendering), the page is now static and the initial HTML has no knowledge about dynamic values in the URL, like `id`, which becomes available after the first render.
+This happens because of [Automatic Prerendering](https://nextjs.org/docs#automatic-prerendering), the page is static and the initial HTML has no knowledge about dynamic values in the URL, like `id`, which becomes available after the first render.
 
 And why is `useEffect` not fetching the data after the id is available? because in order to do that we need to include it to the dependencies, in the same way we had it before.
 

--- a/pages/learn/excel/csr/automatic-prerendering.mdx
+++ b/pages/learn/excel/csr/automatic-prerendering.mdx
@@ -1,0 +1,28 @@
+import Layout from '../../../../components/learn/Layout';
+import AnswerBox from '../../../../components/learn/AnswerBox';
+
+export const meta = {
+  title: 'CSR',
+  courseId: 'excel',
+  lessonId: 'csr',
+  stepId: 'automatic-prerendering'
+};
+
+## Automatic Prerendering
+
+After refreshing the page, it gets stuck in `Loading...`, but why is that?
+
+Open the dev tools and you should see the following two logs:
+
+```js
+id: undefined;
+id: '975';
+```
+
+the id is `undefined` in the first render but then it changes to `975`, which is the id for http://localhost:3000/p/975.
+
+This happens because of [Automatic Prerendering](https://nextjs.org/docs#automatic-prerendering), the page is now static and the initial HTML has no knowledge about dynamic values in the URL, like `id`, which becomes available after the first render.
+
+And why is `useEffect` not fetching the data after the id is available? because in order to do that we need to include it to the dependencies, in the same way we had it before.
+
+export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/excel/csr/browser-apis-2.mdx
+++ b/pages/learn/excel/csr/browser-apis-2.mdx
@@ -1,0 +1,45 @@
+import Layout from '../../../../components/learn/Layout';
+import AnswerBox from '../../../../components/learn/AnswerBox';
+
+export const meta = {
+  title: 'CSR',
+  courseId: 'excel',
+  lessonId: 'csr',
+  stepId: 'browser-apis-2'
+};
+
+## Browser APIs
+
+Similar to the same problem as before, because our page is first prerendered in a Node.js environment, we can't access Browser APIs like `localStorage`, `document`, e.t.c, in the first render.
+
+Open `lib/shows.js` and replace the implementation of `useLocalStorage` with the following code:
+
+```jsx
+const getItem = name => JSON.parse(localStorage.getItem(name));
+let isPageReady = false;
+
+export function useLocalStorage(name) {
+  const [item, setState] = useState(isPageReady ? getItem(name) : null);
+  const setItem = value => {
+    if (name) {
+      localStorage.setItem(name, JSON.stringify(value));
+      setState(value);
+    }
+  };
+
+  useEffect(() => {
+    isPageReady = true;
+    if (name) {
+      setState(getItem(name));
+    }
+  }, [name]);
+
+  return [item, setItem];
+}
+```
+
+In the above changes there's a new variable called `isPageReady`, it decides if we should use `localStorage` in the first render or wait for `useEffect`, the first case would be a refresh or first page view, and the latter a navigation between prefetched pages.
+
+Now play with the app again and you should see how the cache is getting rid of all loading states, even though the delay is still there.
+
+export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/excel/csr/browser-apis-2.mdx
+++ b/pages/learn/excel/csr/browser-apis-2.mdx
@@ -10,7 +10,7 @@ export const meta = {
 
 ## Browser APIs
 
-Similar to the same problem as before, because our page is first prerendered in a Node.js environment, we can't access Browser APIs like `localStorage`, `document`, e.t.c, in the first render.
+Similar to the same problem as before, because our page is first prerendered in a Node.js environment, we can't access browser APIs like `localStorage`, `document`, e.t.c, in the first render.
 
 Open `lib/shows.js` and replace the implementation of `useLocalStorage` with the following code:
 

--- a/pages/learn/excel/csr/browser-apis.mdx
+++ b/pages/learn/excel/csr/browser-apis.mdx
@@ -1,0 +1,56 @@
+import Layout from '../../../../components/learn/Layout';
+import AnswerBox from '../../../../components/learn/AnswerBox';
+
+export const meta = {
+  title: 'CSR',
+  courseId: 'excel',
+  lessonId: 'csr',
+  stepId: 'browser-apis',
+  question: {
+    answers: [
+      'Error: localStorage is not defined',
+      'The data loads faster',
+      'The page takes more time to render',
+      'Error: localStorage can not be used in hooks'
+    ],
+    correctAnswer: 'Error: localStorage is not defined'
+  }
+};
+
+## Browser APIs
+
+Our fetchs are taking too long, but we can cache the data to not fetch it again unless needed, and we can use `localStorage` for that.
+
+Open `lib/shows.js` and add the following code at the end:
+
+```jsx
+const getItem = name => JSON.parse(localStorage.getItem(name));
+
+export function useLocalStorage(name) {
+  const [item, setState] = useState(getItem(name));
+  const setItem = value => {
+    if (name) {
+      localStorage.setItem(name, JSON.stringify(value));
+      setState(value);
+    }
+  };
+
+  return [item, setItem];
+}
+```
+
+Now inside `useShows` replace `useState()` with:
+
+```jsx
+const [shows, setShows] = useLocalStorage('shows');
+```
+
+And for `useShow`:
+
+```jsx
+const [show, setShow] = useLocalStorage(id && `show.${id}`);
+```
+
+What can you notice after refreshing a page?
+
+export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/excel/csr/browser-apis.mdx
+++ b/pages/learn/excel/csr/browser-apis.mdx
@@ -19,7 +19,7 @@ export const meta = {
 
 ## Browser APIs
 
-Our fetchs are taking too long, but we can cache the data to not fetch it again unless needed, and we can use `localStorage` for that.
+Our fetches are taking too long, but we can cache the data to not fetch it again unless needed, and we can use `localStorage` for that.
 
 Open `lib/shows.js` and add the following code at the end:
 

--- a/pages/learn/excel/csr/client-side-fetching.mdx
+++ b/pages/learn/excel/csr/client-side-fetching.mdx
@@ -1,0 +1,108 @@
+import Layout from '../../../../components/learn/Layout';
+import AnswerBox from '../../../../components/learn/AnswerBox';
+
+export const meta = {
+  title: 'CSR',
+  courseId: 'excel',
+  lessonId: 'csr',
+  stepId: 'client-side-fetching',
+  question: {
+    answers: [
+      'The page rendered a different show',
+      'The page is working as usual',
+      'An unexpected error happened',
+      'The page is stuck at Loading...'
+    ],
+    correctAnswer: 'The page is stuck at Loading...'
+  }
+};
+
+## Client Side Fetching
+
+To use our custom hooks for data fetching open `pages/index.js` and replace the content with the following:
+
+```jsx
+import Layout from '../components/MyLayout.js';
+import Link from 'next/link';
+import { useShows } from '../lib/shows.js';
+
+const Index = () => {
+  const shows = useShows();
+
+  return (
+    <Layout>
+      <h1>Batman TV Shows</h1>
+      {shows ? (
+        <ul>
+          {shows.map(show => (
+            <li key={show.id}>
+              <Link href="/p/[id]" as={`/p/${show.id}`}>
+                <a>{show.name}</a>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>Loading...</p>
+      )}
+    </Layout>
+  );
+};
+
+export default Index;
+```
+
+Now open `pages/p/[id].js` and do the same, but with `useShow()`:
+
+```jsx
+import { useRouter } from 'next/router';
+import Layout from '../../components/MyLayout';
+import { useShow } from '../../lib/shows';
+
+const Post = () => {
+  const router = useRouter();
+  const show = useShow(router.query.id);
+
+  return (
+    <Layout>
+      {show ? (
+        <>
+          <h1>{show.name}</h1>
+          <p>{show.summary.replace(/<[/]?p>/g, '')}</p>
+          <img src={show.image.medium} />
+        </>
+      ) : (
+        <p>Loading...</p>
+      )}
+    </Layout>
+  );
+};
+
+export default Post;
+```
+
+Navigations should feel very different now and you shouldn't see any kind of delay between navigations.
+
+Let's do a small change, open `lib/shows.js` and replace the `useShow()` hook with the following:
+
+```jsx
+export function useShow(id) {
+  const [show, setShow] = useState();
+
+  console.log('id:', id);
+
+  useEffect(() => {
+    if (id) {
+      return fetchShows(setShow, id);
+    }
+  }, []);
+
+  return show;
+}
+```
+
+2 changes were introduced, we added a `console.log` for the `id` and removed `id` from the dependencies in `useEffect`.
+
+Now if you go to any of the shows (e.g http://localhost:3000/p/975), and refresh the page, what can you notice?
+
+export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/excel/csr/common-hooks.mdx
+++ b/pages/learn/excel/csr/common-hooks.mdx
@@ -34,36 +34,40 @@ export async function getShows(id) {
   }
 }
 
+function fetchShows(setData, id) {
+  let isMounted = true;
+
+  const fetchData = async () => {
+    const shows = await getShows(id);
+    // Only change the state if the component is still mounted after the fetch finishes
+    if (isMounted) {
+      setData(shows);
+    }
+  };
+  fetchData();
+
+  // This function will be executed by useEffect if the component is unmounted
+  return () => {
+    isMounted = false;
+  };
+}
+
 export function useShows() {
   const [shows, setShows] = useState();
 
   useEffect(() => {
-    const fetchData = async () => {
-      const shows = await getShows();
-      setShows(shows);
-    };
-    fetchData();
+    return fetchShows(setShows);
   }, []);
 
   return shows;
 }
-```
 
-`useShows()` follows the [name convention for hooks](https://reactjs.org/docs/hooks-overview.html#building-your-own-hooks), it fetches and returns the shows to any component using it.
-
-We could also do the same to get the data about a single show, add the following code to the end of the file:
-
-```jsx
 export function useShow(id) {
   const [show, setShow] = useState();
 
   useEffect(() => {
     if (id) {
-      const fetchData = async () => {
-        const show = await getShows(id);
-        setShow(show);
-      };
-      fetchData();
+      return fetchShows(setShow, id);
     }
   }, [id]);
 
@@ -71,8 +75,10 @@ export function useShow(id) {
 }
 ```
 
-`useShow` receives an `id` and uses it to fetch the show, the `useEffect` in this case has `id` as a dependency, so whenever `id` changes, it'll fetch the show, we also have a conditional to only fetch the show if there's an `id`
+`useShows` and `useShow` follow the [name convention for hooks](https://reactjs.org/docs/hooks-overview.html#building-your-own-hooks), they fetch and return shows to any component using them.
 
-Our new hooks are ready, in the next step we'll add them to the pages, you can also to do it yourself before continuing with the next step.
+`useShow` receives an `id` and uses it to fetch the show, it also has `id` as a dependency, so whenever `id` changes it will fetch the show. We also have a conditional to only fetch the show if there's an `id`.
+
+Our new hooks are ready, in the next step we'll add them to the pages, you can also do it yourself before continuing with the next step.
 
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/excel/csr/common-hooks.mdx
+++ b/pages/learn/excel/csr/common-hooks.mdx
@@ -5,45 +5,74 @@ export const meta = {
   title: 'CSR',
   courseId: 'excel',
   lessonId: 'csr',
-  stepId: 'ssr-app',
-  question: {
-    answers: [
-      'The index page now shows a loading while the fetch finishes',
-      'It takes more time to navigate between pages',
-      'A delay was introduced, but only in the first render',
-      'Navigations are just fine'
-    ],
-    correctAnswer: 'It takes more time to navigate between pages'
-  }
+  stepId: 'common-hooks'
 };
 
 ## Common Hooks
 
-You may have noticed something while playing with the app that there are no loading states between page navigations, once you navigate the data is already there and the page is ready, that's the magic of Server Side Rendering.
+React Hooks are very powerful as you can see, and we can improve our current implementation even more.
 
-But what would happen if the request takes too long? Open `pages/index.js` and replace the current `getInitialProps` with the following:
+Let's start by moving our new data fetch hook to a common lib, that way we can use it in any component, open `lib/shows.js` and replace the content with the following:
 
 ```jsx
-Index.getInitialProps = async function() {
+import { useState, useEffect } from 'react';
+import fetch from 'isomorphic-unfetch';
+
+export async function getShows(id) {
   await new Promise(resolve => setTimeout(() => resolve(), 1000));
 
-  const res = await fetch('https://api.tvmaze.com/search/shows?q=batman');
-  const data = await res.json();
+  if (id) {
+    const res = await fetch(`https://api.tvmaze.com/shows/${id}`);
+    const show = await res.json();
 
-  return {
-    shows: data.map(entry => entry.show)
-  };
-};
+    return show;
+  } else {
+    const res = await fetch('https://api.tvmaze.com/search/shows?q=batman');
+    const data = await res.json();
+
+    return data.map(entry => entry.show);
+  }
+}
+
+export function useShows() {
+  const [shows, setShows] = useState();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const shows = await getShows();
+      setShows(shows);
+    };
+    fetchData();
+  }, []);
+
+  return shows;
+}
 ```
 
-This is the the only change we have introduced to the page:
+`useShows()` follows the [name convention for hooks](https://reactjs.org/docs/hooks-overview.html#building-your-own-hooks), it fetches and returns the shows to any component using it.
 
-```js
-await new Promise(resolve => setTimeout(() => resolve(), 1000));
+We could also do the same to get the data about a single show, add the following code to the end of the file:
+
+```jsx
+export function useShow(id) {
+  const [show, setShow] = useState();
+
+  useEffect(() => {
+    if (id) {
+      const fetchData = async () => {
+        const show = await getShows(id);
+        setShow(show);
+      };
+      fetchData();
+    }
+  }, [id]);
+
+  return show;
+}
 ```
 
-We added a delay to the fetch call, this would mean the render will take 1 second longer, you can also do the same by adding some `throttling` in the Network tab in devtools.
+`useShow` receives an `id` and uses it to fetch the show, the `useEffect` in this case has `id` as a dependency, so whenever `id` changes, it'll fetch the show, we also have a conditional to only fetch the show if there's an `id`
 
-Now that we have simulated a slow connection (or a very long fetch operation), what can you notice after navigating between the index page and other routes?
+Our new hooks are ready, in the next step we'll add them to the pages, you can also to do it yourself before continuing with the next step.
 
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/excel/csr/common-hooks.mdx
+++ b/pages/learn/excel/csr/common-hooks.mdx
@@ -1,0 +1,49 @@
+import Layout from '../../../../components/learn/Layout';
+import AnswerBox from '../../../../components/learn/AnswerBox';
+
+export const meta = {
+  title: 'CSR',
+  courseId: 'excel',
+  lessonId: 'csr',
+  stepId: 'ssr-app',
+  question: {
+    answers: [
+      'The index page now shows a loading while the fetch finishes',
+      'It takes more time to navigate between pages',
+      'A delay was introduced, but only in the first render',
+      'Navigations are just fine'
+    ],
+    correctAnswer: 'It takes more time to navigate between pages'
+  }
+};
+
+## Common Hooks
+
+You may have noticed something while playing with the app that there are no loading states between page navigations, once you navigate the data is already there and the page is ready, that's the magic of Server Side Rendering.
+
+But what would happen if the request takes too long? Open `pages/index.js` and replace the current `getInitialProps` with the following:
+
+```jsx
+Index.getInitialProps = async function() {
+  await new Promise(resolve => setTimeout(() => resolve(), 1000));
+
+  const res = await fetch('https://api.tvmaze.com/search/shows?q=batman');
+  const data = await res.json();
+
+  return {
+    shows: data.map(entry => entry.show)
+  };
+};
+```
+
+This is the the only change we have introduced to the page:
+
+```js
+await new Promise(resolve => setTimeout(() => resolve(), 1000));
+```
+
+We added a delay to the fetch call, this would mean the render will take 1 second longer, you can also do the same by adding some `throttling` in the Network tab in devtools.
+
+Now that we have simulated a slow connection (or a very long fetch operation), what can you notice after navigating between the index page and other routes?
+
+export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/excel/csr/finally.mdx
+++ b/pages/learn/excel/csr/finally.mdx
@@ -16,6 +16,6 @@ By knowing the differences between a server side rendering and a prerendered pag
 
 You don't have to pick one method over the other, you may pick SSR for a page, CSR for another, or even do both in another page, then create isomorphic hooks and components that can work in any scenario.
 
-Next.js gives you the tools so you can build the site in your own way.
+Next.js gives you the tools so you can build your app in your own way.
 
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/excel/csr/finally.mdx
+++ b/pages/learn/excel/csr/finally.mdx
@@ -1,0 +1,21 @@
+import Layout from '../../../../components/learn/Layout';
+import AnswerBox from '../../../../components/learn/AnswerBox';
+
+export const meta = {
+  title: 'CSR',
+  courseId: 'excel',
+  lessonId: 'csr',
+  stepId: 'finally'
+};
+
+## Finally
+
+That's it for this lesson, you should be able to understand the small details of using Next.js in an isomorphic environment.
+
+By knowing the differences between a server side rendering and a prerendered page you should be able to decide what's better for you.
+
+You don't have to pick one method over the other, you may pick SSR for a page, CSR for another, or even do both in another page, then create isomorphic hooks and components that can work in any scenario.
+
+Next.js gives you the tools so you can build the site in your own way.
+
+export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/excel/csr/hooks.mdx
+++ b/pages/learn/excel/csr/hooks.mdx
@@ -1,0 +1,60 @@
+import Layout from '../../../../components/learn/Layout';
+
+export const meta = {
+  title: 'CSR',
+  courseId: 'excel',
+  lessonId: 'csr',
+  stepId: 'hooks'
+};
+
+## React Hooks
+
+To move our data fetch to the client we'll use [useState](https://reactjs.org/docs/hooks-state.html) to save the data and [useEffect](https://reactjs.org/docs/hooks-effect.html) to do the fetch.
+
+Replace the content of `pages/index.js` with the following:
+
+```jsx
+import { useState, useEffect } from 'react';
+import Layout from '../components/MyLayout.js';
+import Link from 'next/link';
+import getShows from '../lib/shows.js';
+
+const Index = () => {
+  const [shows, setShows] = useState();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const shows = await getShows();
+      setShows(shows);
+    };
+    fetchData();
+  }, []);
+
+  return (
+    <Layout>
+      <h1>Batman TV Shows</h1>
+      {shows ? (
+        <ul>
+          {shows.map(show => (
+            <li key={show.id}>
+              <Link href="/p/[id]" as={`/p/${show.id}`}>
+                <a>{show.name}</a>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>Loading...</p>
+      )}
+    </Layout>
+  );
+};
+
+export default Index;
+```
+
+With the above changes we moved the data fetch to hooks, now page transitions are very fast between other pages and our index page, even though we haven't removed the 1 second delay.
+
+The page is also static thanks to the lack of `getInitialProps`.
+
+export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/excel/csr/hooks.mdx
+++ b/pages/learn/excel/csr/hooks.mdx
@@ -17,7 +17,7 @@ Replace the content of `pages/index.js` with the following:
 import { useState, useEffect } from 'react';
 import Layout from '../components/MyLayout.js';
 import Link from 'next/link';
-import getShows from '../lib/shows.js';
+import { getShows } from '../lib/shows.js';
 
 const Index = () => {
   const [shows, setShows] = useState();

--- a/pages/learn/excel/csr/hooks.mdx
+++ b/pages/learn/excel/csr/hooks.mdx
@@ -55,6 +55,8 @@ export default Index;
 
 With the above changes we moved the data fetch to hooks, now page transitions are very fast between other pages and our index page, even though we haven't removed the 1 second delay.
 
+`useEffect` executes the function right after the first render and always in the browser, it uses the array in the second argument to re-execute the function when any of the values (a.k.a dependencies) inside the array changes, because our dependencies are an empty array (`[]`) then our function will only run once.
+
 The page is also static thanks to the lack of `getInitialProps`.
 
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/excel/csr/index.mdx
+++ b/pages/learn/excel/csr/index.mdx
@@ -6,7 +6,7 @@ export const meta = {
   lessonId: 'csr'
 };
 
-Next.js is server rendered by default, meaning your code will not always run in a browser. This is specially true for pages using `getInitialProps`, which will be rendered in your server first before sending the HTML to the browser
+Next.js server-side renders your pages. When a page has `getInitialProps` this is done in each request, when it doesn't we are able to server-side render it once and reuse that result for each request. During this server-side render certain browser APIs are not available.
 
 This lesson will focus on understanding the way React works in both environments (server and browser).
 

--- a/pages/learn/excel/csr/index.mdx
+++ b/pages/learn/excel/csr/index.mdx
@@ -1,0 +1,19 @@
+import Layout from '../../../../components/learn/Layout';
+
+export const meta = {
+  title: 'CSR',
+  courseId: 'excel',
+  lessonId: 'csr'
+};
+
+Next.js is server rendered by default, meaning your code will not always run in a browser. This is specially true for pages using `getInitialProps`, which will be rendered in your server first before sending the HTML to the browser
+
+This lesson will focus on understanding the way React works in both environments (server and browser).
+
+To go through this lesson it's recommended to have a previous knowledge of:
+
+- The basic lessons
+- [React Hooks](https://reactjs.org/docs/hooks-intro.html)
+- [Automatic Prerendering](https://nextjs.org/learn/excel/automatic-prerendering)
+
+export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/excel/csr/setup.mdx
+++ b/pages/learn/excel/csr/setup.mdx
@@ -1,0 +1,32 @@
+import Layout from '../../../../components/learn/Layout';
+import AnswerBox from '../../../../components/learn/AnswerBox';
+
+export const meta = {
+  title: 'CSR',
+  courseId: 'excel',
+  lessonId: 'csr',
+  stepId: 'setup'
+};
+
+## Setup
+
+In this lesson, we need a simple Next.js app to play with. Try downloading the following example app:
+
+```bash
+git clone https://github.com/zeit/next-learn-demo.git
+cd next-learn-demo
+cd E4-csr
+```
+
+You can run it with:
+
+```bash
+npm install
+npm run dev
+```
+
+Now you can access the app by going to http://localhost:3000.
+
+The example app shows a list of batman shows in the home page, and you can navigate to every show by clicking on it.
+
+export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/excel/csr/slow-navigation.mdx
+++ b/pages/learn/excel/csr/slow-navigation.mdx
@@ -11,8 +11,8 @@ export const meta = {
 
 Route navigations were slow after introducing a delay, that's because the page won't be rendered until `getInitialProps` has ended.
 
-The user has to wait a long time because a data fetch has not finished, and can end with the conclusion that the site is slow, this is especially harmful in the case of slow connections
+The user has to wait a long time because a data fetch has not finished, and can end with the conclusion that the site is slow, this is especially harmful in the case of slow connections.
 
-What can we do to fix the above issue? Switch to a client side fetch!
+What can we do to fix the above issue? Switch to a client-side fetch!
 
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/excel/csr/slow-navigation.mdx
+++ b/pages/learn/excel/csr/slow-navigation.mdx
@@ -1,0 +1,18 @@
+import Layout from '../../../../components/learn/Layout';
+
+export const meta = {
+  title: 'CSR',
+  courseId: 'excel',
+  lessonId: 'csr',
+  stepId: 'slow-navigation'
+};
+
+## Slow Navigation
+
+Route navigations were slow after introducing a delay, that's because the page won't be rendered until `getInitialProps` has ended.
+
+The user has to wait a long time because a data fetch has not finished, and can end with the conclusion that the site is slow, this is especially harmful in the case of slow connections
+
+What can we do to fix the above issue? Switch to a client side fetch!
+
+export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/pages/learn/excel/csr/ssr-app.mdx
+++ b/pages/learn/excel/csr/ssr-app.mdx
@@ -1,0 +1,34 @@
+import Layout from '../../../../components/learn/Layout';
+import AnswerBox from '../../../../components/learn/AnswerBox';
+
+export const meta = {
+  title: 'CSR',
+  courseId: 'excel',
+  lessonId: 'csr',
+  stepId: 'ssr-app',
+  question: {
+    answers: [
+      'The index page now shows a loading while the fetch finishes',
+      'It takes more time to navigate between pages',
+      'A delay was introduced, but only in the first render',
+      'Navigations are just fine'
+    ],
+    correctAnswer: 'It takes more time to navigate between pages'
+  }
+};
+
+## Server Rendered App
+
+You may have noticed something while playing with the app that there are no loading states between page navigations, once you navigate the data is already there and the page is ready, that's the magic of Server Side Rendering.
+
+But what would happen if the request takes too long? Open `lib/shows.js` and add the following line to the beginning of the `getShows` function:
+
+```js
+await new Promise(resolve => setTimeout(() => resolve(), 1000));
+```
+
+We added a delay of 1 second to `getShows`, which is being used inside the pages to fetch the shows, it would mean the render will take much longer. You can also do the same by adding some `throttling` in the Network tab in devtools.
+
+Now that we have simulated a slow connection (or a very long data fetch), what can you notice after navigating between routes?
+
+export default ({ children }) => <Layout meta={meta}>{children}</Layout>;


### PR DESCRIPTION
**Note:** I haven't picked a title for this lesson, I'm taking ideas.

The lesson talks about migrating a SSR app to a CSR app with hooks, it explains some concepts that may not be very clear to people using hooks in Next.js, like that browser APIs are not available in the first render outside `useEffect` and that `router.query` is empty in the first render.

The example app is here: https://github.com/zeit/next-learn-demo/pull/17