### PR TITLE
Fix postcss config for Learn

### DIFF
--- a/pages/learn/basics/assets-metadata-css/styling-tips.mdx
+++ b/pages/learn/basics/assets-metadata-css/styling-tips.mdx
@@ -60,10 +60,13 @@ Out of the box, with no configuration, Next.js compiles CSS using [PostCSS](http
 
 To customize PostCSS config, you can create a top-level file called `postcss.config.js`. This is useful if you’re using libraries like [Tailwind CSS](https://tailwindcss.com/).
 
-Here’s an example `postcss.config.js` for using [Tailwind CSS](https://tailwindcss.com/) with [`purgecss`](https://github.com/FullHuman/purgecss) which removes unused CSS.
+Here’s an instruction for using [Tailwind CSS](https://tailwindcss.com/). We recommend using `postcss-preset-env` and `postcss-flexbugs-fixes` to match <Link href="/docs/[...slug]" as="/docs/advanced-features/customizing-postcss-config#default-behavior"><a>Next.js’s default behavior</a></Link>. First, install the packages:
 
-- You need to install `tailwindcss`, `@fullhuman/postcss-purgecss`, and `postcss-preset-env`.
-- You don’t need `autoprefixer` because Next.js includes it by default.
+```bash
+npm install tailwindcss postcss-preset-env postcss-flexbugs-fixes
+```
+
+Then write the following for `postcss.config.js`:
 
 ```js
 module.exports = {
@@ -71,21 +74,36 @@ module.exports = {
     'tailwindcss',
     ...(process.env.NODE_ENV === 'production'
       ? [
+          'postcss-flexbugs-fixes',
           [
-            '@fullhuman/postcss-purgecss',
+            'postcss-preset-env',
             {
-              content: [
-                './pages/**/*.{js,jsx,ts,tsx}',
-                './components/**/*.{js,jsx,ts,tsx}'
-              ],
-              defaultExtractor: content =>
-                content.match(/[\w-/:]+(?<!:)/g) || []
+              autoprefixer: {
+                flexbox: 'no-2009'
+              },
+              stage: 3,
+              features: {
+                'custom-properties': false
+              }
             }
           ]
         ]
-      : []),
-    'postcss-preset-env'
+      : [])
   ]
+}
+```
+
+We also recommend [removing unused CSS](https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css) by specifying the `purge` option on `tailwind.config.js`:
+
+```js
+// tailwind.config.js
+module.exports = {
+  purge: [
+    // Use *.tsx if using TypeScript
+    './pages/**/*.js',
+    './components/**/*.js'
+  ]
+  // ...
 }
 ```
 

--- a/pages/learn/basics/assets-metadata-css/styling-tips.mdx
+++ b/pages/learn/basics/assets-metadata-css/styling-tips.mdx
@@ -62,7 +62,7 @@ To customize PostCSS config, you can create a top-level file called `postcss.con
 
 Here’s an instruction for using [Tailwind CSS](https://tailwindcss.com/). We recommend using `postcss-preset-env` and `postcss-flexbugs-fixes` to match <Link href="/docs/[...slug]" as="/docs/advanced-features/customizing-postcss-config#default-behavior"><a>Next.js’s default behavior</a></Link>. First, install the packages:
 
-```bash
+```shell
 npm install tailwindcss postcss-preset-env postcss-flexbugs-fixes
 ```
 

--- a/pages/learn/basics/assets-metadata-css/styling-tips.mdx
+++ b/pages/learn/basics/assets-metadata-css/styling-tips.mdx
@@ -72,23 +72,19 @@ Then write the following for `postcss.config.js`:
 module.exports = {
   plugins: [
     'tailwindcss',
-    ...(process.env.NODE_ENV === 'production'
-      ? [
-          'postcss-flexbugs-fixes',
-          [
-            'postcss-preset-env',
-            {
-              autoprefixer: {
-                flexbox: 'no-2009'
-              },
-              stage: 3,
-              features: {
-                'custom-properties': false
-              }
-            }
-          ]
-        ]
-      : [])
+    'postcss-flexbugs-fixes',
+    [
+      'postcss-preset-env',
+      {
+        autoprefixer: {
+          flexbox: 'no-2009'
+        },
+        stage: 3,
+        features: {
+          'custom-properties': false
+        }
+      }
+    ]
   ]
 }
 ```


### PR DESCRIPTION
- Make postcss plugins the same for both production and development. This is more consistent with [what Next.js does by default](https://github.com/vercel/next.js/blob/57535b5afc3782728822576603fd48ea5539941b/packages/next/build/webpack/config/blocks/css/plugins.ts#L86-L103).
- Remove `@fullhuman/postcss-purgecss` in favor of [Tailwind’s built-in purge functionality](https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css)
- Specify `postcss-preset-env` and `postcss-flexbugs-fixes` to match [Next’s default config](https://nextjs.org/docs/advanced-features/customizing-postcss-config#customizing-plugins)