### PR TITLE
Fixed implement-getstaticprops documentation

### DIFF
--- a/pages/learn/basics/data-fetching/implement-getstaticprops.mdx
+++ b/pages/learn/basics/data-fetching/implement-getstaticprops.mdx
@@ -49,7 +49,7 @@ export function getSortedPostsData() {
   })
   // Sort posts by date
   return allPostsData.sort((a, b) => {
-    if (a.date < b.date) {
+    if (Date(a.data.date) < Date(b.data.date)) {
       return 1
     } else {
       return -1


### PR DESCRIPTION
`gray-matter` parses the markdown and includes the metadata in the `data` property and returns it.

As described below.

```
{
    ...,
    data: { title: 'Two Forms of Pre-rendering', date: '2020-01-01' }
}
```

So I fixed it as follows
- fixed to get `date` property from `data` object
- `date` property is a string, so I initialized by `Date` class and compared.
