### PR TITLE
feat(next/docs): docs should now be synced to canary

### DIFF
--- a/lib/docs/page.js
+++ b/lib/docs/page.js
@@ -6,7 +6,7 @@ import { TAG, FORCE_TAG } from './config';
 export async function getCurrentTag(tag) {
   if (tag) return tag;
   if (FORCE_TAG) return TAG;
-  return getLatestTag();
+  return 'canary';
 }
 
 export async function fetchDocsManifest(tag) {

--- a/next.config.js
+++ b/next.config.js
@@ -18,7 +18,7 @@ const withGitHubMDX = nextMDX({
         rehypeReadme,
         {
           repo: 'vercel/next.js',
-          branch: 'master',
+          branch: 'canary',
           level: 4
         }
       ]

--- a/pages/docs/[[...slug]].js
+++ b/pages/docs/[[...slug]].js
@@ -177,6 +177,7 @@ const Docs = ({ routes, route: _route, data, html }) => {
 
 export async function getStaticPaths() {
   const tag = await getCurrentTag();
+
   const manifest = await fetchDocsManifest(tag);
   return { paths: getPaths(manifest.routes), fallback: true };
 }


### PR DESCRIPTION
Addresses Issue https://github.com/vercel/next.js/issues/14402
This should link the nextjs.org docs with the canary branch without (hopefully) causing any issues with urls containing the **tag** slug.
