### PR TITLE
Remove unnecessary "as" for Link.

### DIFF
--- a/pages/learn/basics/deploying-nextjs-app/deploy.mdx
+++ b/pages/learn/basics/deploying-nextjs-app/deploy.mdx
@@ -16,8 +16,8 @@ The easiest way to deploy Next.js to production is to use the **<PlatformLink />
 <p>
   <PlatformText /> is an all-in-one platform with Global CDN supporting static &
   JAMstack deployment and Serverless Functions. We believe <PlatformText /> is
-  the optimal place to deploy Next.js apps. You can start using it for _free_ —
-  no credit card required.
+  the optimal place to deploy Next.js apps. You can start using it for free — no
+  credit card required.
 </p>
 
 ### Create a <PlatformText /> Account

--- a/pages/learn/basics/dynamic-routes/polishing-index-page.mdx
+++ b/pages/learn/basics/dynamic-routes/polishing-index-page.mdx
@@ -9,21 +9,17 @@ export const meta = {
   subtitle: 'Polishing the Index Page'
 }
 
-As the final step, let’s update our index page (`pages/index.js`).
-
-In particular, we need to add links to each post page. We’ll be using the [`Link`](/docs/api-reference/next/link) component, but we need to do something differently this time.
-
-To link to a page with dynamic routes, you need to use the [`Link`](/docs/api-reference/next/link) component differently. In our case, to link to `/posts/ssg-ssr`, you need to write it like this:
+First, let’s update our index page (`pages/index.js`).
+We need to add links to each post page using the [`Link`](/docs/api-reference/next/link) component.
 
 ```jsx
-<Link href="/posts/[id]" as="/posts/ssg-ssr">
+<Link href={`/posts/${id}`}>
   <a>...</a>
 </Link>
 ```
 
-As you can see, you need to use `[id]` for `href` and the actual path (`ssg-ssr`) for the `as` prop.
-
-Let’s implement it. First, import [`Link`](/docs/api-reference/next/link) and `Date` in `pages/index.js`:
+`/posts/${id}` will transform into the actual path (`/posts/ssg-ssr`) when compiled. Let's import
+[`Link`](/docs/api-reference/next/link) and `Date` in `pages/index.js`:
 
 ```js
 import Link from 'next/link'
@@ -34,7 +30,7 @@ Then, near the bottom of the `Home` component, replace the `li` tag with the fol
 
 ```jsx
 <li className={utilStyles.listItem} key={id}>
-  <Link href="/posts/[id]" as={`/posts/${id}`}>
+  <Link href={`/posts/${id}`}>
     <a>{title}</a>
   </Link>
   <br />
@@ -44,7 +40,7 @@ Then, near the bottom of the `Home` component, replace the `li` tag with the fol
 </li>
 ```
 
-It should now have the links to each article:
+It should now have links to each article:
 
 <Image
   shadow
@@ -55,7 +51,7 @@ It should now have the links to each article:
   height={472 / 2}
 />
 
-> If something is not working, make sure that your code [looks like this](https://github.com/vercel/next-learn-starter/tree/master/api-routes-starter).
+> If something is not working, make sure that your code [looks like this](https://github.com/vercel/next-learn-starter/tree/master/dynamic-routes-starter).
 
 That’s it! Before we wrap up this lesson, let’s talk about some tips for [dynamic routes](/docs/routing/dynamic-routes) on the next page.
 


### PR DESCRIPTION
`next-learn-starter` corresponding PR: https://github.com/vercel/next-learn-starter/pull/14

This was introduced with https://github.com/vercel/next.js/pull/15231 and is available from in `v9.5.3`.