### PR TITLE
No text showing on Debian

### DIFF
--- a/components/css-config.js
+++ b/components/css-config.js
@@ -1,5 +1,5 @@
 export const FONT_FAMILY_SANS =
-  "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif";
+  "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif";
 
 export const FONT_FAMILY_MONO =
   'Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif';


### PR DESCRIPTION
Hey guys!

Not sure what you think of this, when I go to https://nextjs.org/ I can't see any text. The website looks like this to me:

![next-js-site](https://user-images.githubusercontent.com/1497469/93370500-d26e5000-f848-11ea-8cbc-e4221a16d203.png)

I tried on both Chromium and Firefox, same result. I tried removing the Inter font and it seems to fix the problem. Maybe there's something to update on my Debian system, haven't looked that much into the issue yet.

My operating system:
```
Debian GNU/Linux 9.9 (stretch)
Kernel 4.9.0-9-amd64 x86_64 (64 bit gcc: 6.3.0)
```

Chromium:
```
Version 73.0.3683.75 (Developer Build) built on Debian 9.8, running on Debian 9.9 (64-bit)
```

Firefox
```
Firefox Quantum 68.12.0esr (64-bit)
```

Let me know what you think :) 