### PR TITLE
Learn: Don't mention `getStaticPaths` until it's covered in question.

### DIFF
--- a/pages/learn/basics/data-fetching/getstaticprops-details.mdx
+++ b/pages/learn/basics/data-fetching/getstaticprops-details.mdx
@@ -67,7 +67,7 @@ In cases like this, you can try [**Server-side Rendering**](/docs/basic-features
   correctAnswer="Server-side"
 >
 
-**Quick Review**: Where do `getStaticProps` and `getStaticPaths` run?
+**Quick Review**: Where does `getStaticProps` run?
 
 </AnswerBox>
 


### PR DESCRIPTION
Removes mention of `getStaticPaths` because it hasn't been formally introduced yet. 
![image](https://user-images.githubusercontent.com/9113740/95277063-82b0f200-0812-11eb-9bd1-c0cfdacb7750.png)
