### PR TITLE
Update the Webpack 5 version required by Next.js 9.5.4

### DIFF
--- a/pages/blog/next-9-5.mdx
+++ b/pages/blog/next-9-5.mdx
@@ -477,7 +477,7 @@ in your `package.json`:
 ```json
 {
   "resolutions": {
-    "webpack": "^5.0.0-beta.28"
+    "webpack": "^5.0.0-beta.30"
   }
 }
 ```


### PR DESCRIPTION
While running tests on `next-transpile-modules` with Next.js 9.5.4, our tests for Webpack 5 failed due to the Webpack 5's`beta-28` being used instead of the the `beta-30` used by Next.js right now.

https://github.com/vercel/next.js/blob/5d79a8c0c4928d718e71707cf3305a51c9a5adc4/.github/workflows/build_test_deploy.yml#L110