### PR TITLE
small change in deplyment doc from master branch to main

### DIFF
--- a/pages/learn/basics/deploying-nextjs-app/github.mdx
+++ b/pages/learn/basics/deploying-nextjs-app/github.mdx
@@ -26,7 +26,7 @@ To push to GitHub, you can run the following commands (replace `<username>` with
 
 ```bash
 git remote add origin https://github.com/<username>/nextjs-blog.git
-git push -u origin master
+git push -u origin main
 ```
 
 Once your GitHub repository is ready, continue to the next page.


### PR DESCRIPTION
This is a small change but I hope a significant change to re-naming from `master` branch to `main`.

Starts by encouraging new users to deploy using this naming convention.

ref: https://www.hanselman.com/blog/easily-rename-your-git-default-branch-from-master-to-main

